### PR TITLE
Add anchor links to h2-h6 headers for improved navigation

### DIFF
--- a/lib/curso/pages/markdown_converter.ex
+++ b/lib/curso/pages/markdown_converter.ex
@@ -36,8 +36,14 @@ defmodule Pages.MarkdownConverter do
         wrapper = {"div", attrs, children, %{}}
         {wrapper, nil}
 
-      {"h" <> x, _inner, texts, meta}, nil when x in ~w(1 2 3 4 5 6) ->
-        {{"h#{x}", [{"id", anchor_id(texts)}], texts, meta}, nil}
+      {"h1", _inner, texts, meta}, nil ->
+        {{"h1", [{"id", anchor_id(texts)}], texts, meta}, nil}
+
+      {"h" <> x, _inner, texts, meta}, nil when x in ~w(2 3 4 5 6) ->
+        anchor_link =
+          {"a", [{"href", "#" <> anchor_id(texts)}, {"class", "mdx-header-anchor"}], ["#"], %{}}
+
+        {{"h#{x}", [{"id", anchor_id(texts)}], [anchor_link | texts], meta}, nil}
 
       {_, [], bits, meta} = item, nil ->
         case Map.get(meta, :annotation) do


### PR DESCRIPTION
closes #53


I'm not sure if I should style this anchor and where to do that.
@lubien

<img width="635" alt="image" src="https://github.com/adopt-liveview/adopt-liveview/assets/42756551/cbfde58f-ac9b-480f-8c72-77090bb6beca">
